### PR TITLE
Removed bad implementation of equatable method

### DIFF
--- a/Sources/Networking/Types/ValueBasicType.swift
+++ b/Sources/Networking/Types/ValueBasicType.swift
@@ -14,9 +14,3 @@ extension Swift.Bool: ValueBasicType { }
 extension Swift.Double: ValueBasicType { }
 extension Swift.String: ValueBasicType { }
 extension Swift.Array: ValueBasicType where Element: ValueBasicType { }
-
-extension ValueBasicType {
-    public static func == (lhs: any ValueBasicType, rhs: any ValueBasicType) -> Bool {
-        lhs.description == rhs.description
-    }
-}


### PR DESCRIPTION
The Equatable required method returns error `Member operator '==' of protocol 'ValueBasicType' must have at least one argument of type 'Self'`.

The fix removes it.