### PR TITLE
SwiftyNetworking - minor improvements

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -21,7 +21,7 @@ let package = Package(
         ),
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-syntax.git", from: "602.0.0"),
+        .package(url: "https://github.com/swiftlang/swift-syntax.git", from: "602.0.0"),
     ],
     targets: [
         .macro(

--- a/README.md
+++ b/README.md
@@ -85,10 +85,17 @@ struct ExampleRequest {
 ```swift
 let session = Session()
 let exampleRequest = ExampleRequest(bar: "buzz")
-let (result, error) = await session.send(request: exampleRequest)
+let result = await session.send(exampleRequest)
+
+switch result {
+case let .success(response):
+    print(response.body)
+case let .failure(error):
+    print(error)
+}
 
 if somethingIsWrong {
-    session.cancel(requests: .every(ExampleRequest.self))
+    await session.cancel(.every(ExampleRequest.self))
 }
 ```
 

--- a/Sources/Networking/Session/Implementation/Foundation/URLSessionProvider.swift
+++ b/Sources/Networking/Session/Implementation/Foundation/URLSessionProvider.swift
@@ -61,17 +61,21 @@ extension URLSessionProvider {
     func cancel(requests: Session.RequestType) async {
         switch requests {
         case .allTasks:
-            session.invalidateAndCancel()
-            
+            for task in await session.allTasks {
+                task.cancel()
+            }
+
         case let .every(type):
             let requests = await registry.get(by: type)
             for task in await session.allTasks {
                 if let request = task.originalRequest,
                    let id = request.value(forHTTPHeaderField: "X-Request-ID"),
-                   requests.contains(where: { $0.id.uuidString == id })
+                   requests.contains(where: { $0.uuidString == id })
                 {
                     task.cancel()
-                    await registry.remove(id)
+                    if let uuid = UUID(uuidString: id) {
+                        await registry.remove(uuid)
+                    }
                 }
             }
             
@@ -82,7 +86,7 @@ extension URLSessionProvider {
                     id.uuidString == requestId
                 {
                     task.cancel()
-                    await registry.remove(id.uuidString)
+                    await registry.remove(id)
                 }
             }
         }

--- a/Sources/Networking/Session/Implementation/Foundation/URLSessionProvider.swift
+++ b/Sources/Networking/Session/Implementation/Foundation/URLSessionProvider.swift
@@ -91,7 +91,7 @@ extension URLSessionProvider {
 
 extension URLSessionProvider {
     func resolve<R>(_ request: R) async -> any Request where R: Request {
-        var anyRequest: any Request = request
+        var anyRequest: any Request = request.body
         let configuration = request.resolveConfiguration()
         
         var interceptors = configuration.requestInterceptors

--- a/Sources/Networking/Types/Registry.swift
+++ b/Sources/Networking/Types/Registry.swift
@@ -8,20 +8,18 @@
 import Foundation
 
 internal actor Registry {
-    private var requestTypes: [(id: UUID, type: String)] = []
-    
+    private var requestTypes: [(id: UUID, type: ObjectIdentifier)] = []
+
     func register(_ request: some Request, with id: UUID) {
-        requestTypes.append((id, String(describing: request.self)))
+        requestTypes.append((id, ObjectIdentifier(type(of: request))))
     }
-    
-    func get(by type: any Request.Type) -> [(id: UUID, type: String)] {
-        requestTypes.filter({ $0.type == String(describing: type) })
+
+    func get(by type: any Request.Type) -> [UUID] {
+        requestTypes
+            .filter { $0.type == ObjectIdentifier(type) }
+            .map(\.id)
     }
-    
-    func remove(_ id: String) {
-        requestTypes.removeAll(where: { $0.id.uuidString == id })
-    }
-    
+
     func remove(_ id: UUID) {
         requestTypes.removeAll(where: { $0.id == id })
     }

--- a/Sources/Networking/Types/TopLevelDecoder.swift
+++ b/Sources/Networking/Types/TopLevelDecoder.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public protocol TopLevelDecoder {
+public protocol TopLevelDecoder: Sendable {
     func decode<T>(_ type: T.Type, from data: Data) throws -> T where T : Decodable
 }
 

--- a/Sources/Networking/Types/TopLevelEncoder.swift
+++ b/Sources/Networking/Types/TopLevelEncoder.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public protocol TopLevelEncoder {
+public protocol TopLevelEncoder: Sendable {
     func encode<T>(_ value: T) throws -> Data where T : Encodable
 }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Refactors session cancellation and request registry, fixes request resolution to use `body`, adds `Sendable` to encoder/decoder, updates README usage, and switches `swift-syntax` repo URL.
> 
> - **Networking Core**:
>   - Update `URLSessionProvider.cancel` to cancel tasks explicitly and align with new registry API; adjust `.every`/`.only` matching by `X-Request-ID` and UUID removal.
>   - Fix `resolve(_:)` to start from `request.body` and apply interceptors.
> - **Types**:
>   - Rework `Registry` to track request types via `ObjectIdentifier`; `get(by:)` now returns `[UUID]` and `remove(_:)` accepts `UUID`.
>   - Mark `TopLevelEncoder`/`TopLevelDecoder` as `Sendable`.
> - **Docs**:
>   - README usage updated: `Session.send` call site simplified to return a `Result` with `switch` handling; `session.cancel` is now `await session.cancel(.every(...))`.
> - **Build**:
>   - Change `swift-syntax` dependency URL to `github.com/swiftlang/swift-syntax`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3d32404bbef13114d58573897b8f206ffe421863. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->