### PR TITLE
Fixed @KeyValueBuilder result builder to support all Swift control flow statements

### DIFF
--- a/Sources/Networking/Types/Structures/KeyValueBuilder.swift
+++ b/Sources/Networking/Types/Structures/KeyValueBuilder.swift
@@ -8,8 +8,12 @@
 
 @resultBuilder
 public struct KeyValueBuilder {
-    public static func buildBlock(_ components: any KeyValuePair...) -> [any KeyValuePair] {
-        components
+    public static func buildExpression(_ expression: any KeyValuePair) -> [any KeyValuePair] {
+        [expression]
+    }
+
+    public static func buildBlock(_ components: [any KeyValuePair]...) -> [any KeyValuePair] {
+        components.flatMap { $0 }
     }
 
     public static func buildOptional(_ component: [any KeyValuePair]?) -> [any KeyValuePair] {
@@ -25,6 +29,10 @@ public struct KeyValueBuilder {
     }
 
     public static func buildEither(second component: [any KeyValuePair]) -> [any KeyValuePair] {
+        component
+    }
+
+    public static func buildLimitedAvailability(_ component: [any KeyValuePair]) -> [any KeyValuePair] {
         component
     }
 }


### PR DESCRIPTION
The result builder was missing buildExpression and used incorrect parameter types in buildBlock, causing a compilation error (Argument type '[any KeyValuePair]' does not conform to expected type 'KeyValuePair') when using if let, if-else, for loops, or #available checks inside builder closures.

Changes:
- Added buildExpression to lift single KeyValuePair values into arrays
- Changed buildBlock to accept [any KeyValuePair]... so it composes correctly with results from buildOptional, buildEither, and buildArray
- Added buildLimitedAvailability for if #available(...) support

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to a result builder’s overload set; main risk is subtle compile-time behavior changes in builder call sites.
> 
> **Overview**
> Fixes `@KeyValueBuilder` so builder closures can use Swift control flow (`if`/`if let`/`else`, loops, and `#available`) without type-mismatch compilation errors.
> 
> This adds `buildExpression` to lift a single `KeyValuePair` into an array, updates `buildBlock` to accept variadic `[any KeyValuePair]` and flatten results, and adds `buildLimitedAvailability` for availability-guarded branches.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2e838185287e298556453a626514b4de742c43eb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->